### PR TITLE
[webview_flutter_web] Improve support for JavaScript channels

### DIFF
--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -118,6 +118,15 @@ class WebWebViewController extends PlatformWebViewController {
   ) async {
     void handler(html.Event event) {
       if (event is html.MessageEvent) {
+        final String? iFrameSrc = _webWebViewParams.iFrame.src;
+        if (event.origin.isEmpty || iFrameSrc == null) {
+          return;
+        }
+
+        // Security check
+        if (!iFrameSrc.startsWith(event.origin)) {
+          return;
+        }
         javaScriptChannelParams.onMessageReceived(
             JavaScriptMessage(message: event.data.toString()));
       }

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -127,8 +127,22 @@ class WebWebViewController extends PlatformWebViewController {
         if (!iFrameSrc.startsWith(event.origin)) {
           return;
         }
+
+        // ignore: avoid_dynamic_calls
+        final String? channelName = event.data?['channel'] as String?;
+        if (channelName != javaScriptChannelParams.name) {
+          return;
+        }
+
+        // ignore: avoid_dynamic_calls
+        final String? message = event.data?['message'] as String?;
+        if (message == null) {
+          return;
+        }
+
         javaScriptChannelParams.onMessageReceived(
-            JavaScriptMessage(message: event.data.toString()));
+          JavaScriptMessage(message: message),
+        );
       }
     }
 

--- a/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
+++ b/packages/webview_flutter/webview_flutter_web/lib/src/web_webview_controller.dart
@@ -29,7 +29,7 @@ class WebWebViewControllerCreationParams
     // ignore: avoid_unused_constructor_parameters
     PlatformWebViewControllerCreationParams params, {
     @visibleForTesting
-        HttpRequestFactory httpRequestFactory = const HttpRequestFactory(),
+    HttpRequestFactory httpRequestFactory = const HttpRequestFactory(),
   }) : this(httpRequestFactory: httpRequestFactory);
 
   static int _nextIFrameId = 0;
@@ -128,14 +128,18 @@ class WebWebViewController extends PlatformWebViewController {
           return;
         }
 
+        if (event.data == null || event.data is! Map) {
+          return;
+        }
+
         // ignore: avoid_dynamic_calls
-        final String? channelName = event.data?['channel'] as String?;
+        final String? channelName = event.data['channel'] as String?;
         if (channelName != javaScriptChannelParams.name) {
           return;
         }
 
         // ignore: avoid_dynamic_calls
-        final String? message = event.data?['message'] as String?;
+        final String? message = event.data['message'] as String?;
         if (message == null) {
           return;
         }


### PR DESCRIPTION
An improvement on #1. 

_Note_: base branch is [feat/javascript-channels](https://github.com/gynzy/flutter-packages/tree/feat/javascript-channels).

## Improvements

### Security

Incoming messages from other origins are now ignored, as advised on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns).

### Messages processing in case of multiple webview

Previously, if one created _N_ webviews, each message was being processed _N_ times. This can now be prevented by choosing a unique channel name per webview. From web, messages should be send in a slightly different way.

_Before_:

```js
	window.parent.postMessage(message, targetOrigin);
```

_New format_:

```js
	window.parent.postMessage(
		{
			channel: this.channelName,
			message: message,
		},
		targetOrigin
	);
```